### PR TITLE
Handle missing custom properties part.

### DIFF
--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -12,11 +12,20 @@ class CustomProperties(object):
     """
     def __init__(self, doc):
         self.doc = doc
-        part = doc.part.package.part_related_by(RT.CUSTOM_PROPERTIES)
-        self._element = parse_xml(part.blob)
+        self._element = None
+
+        try:
+            part = doc.part.package.part_related_by(RT.CUSTOM_PROPERTIES)
+        except KeyError:
+            pass
+        else:
+            self._element = parse_xml(part.blob)
 
     def dict(self):
         """Returns a dict with all custom doc properties"""
+        if not self._element:
+            return dict()
+
         props = xpath(self._element, './/cp:property')
         return {prop.get('name'): prop[0].text for prop in props}
 


### PR DESCRIPTION
Seems like the custom properties part can be optional. current code expects that it is always there. This PR works aorund that issue with a quick try-except. @buchi feel free to hijack my branch if you see a better solution.

Attached is a file which causes errors without the changes introduced here, you can add it to your "tests" 😉 .

[jahresdossier-2014.docx](https://github.com/4teamwork/docxcompose/files/1491925/jahresdossier-2014.docx)
