### PR TITLE
Only attempt to set the nsid when it is available.

### DIFF
--- a/docxcompose/composer.py
+++ b/docxcompose/composer.py
@@ -285,9 +285,10 @@ class Composer(object):
 
                 # Make sure we have a unique nsid so numberings restart properly
                 nsid = anum_element.find('.//w:nsid', NS)
-                nsid.set(
-                    '{%s}val' % NS['w'],
-                    "{0:0{1}X}".format(random.randint(0, 0xffffffff), 8))
+                if nsid:
+                    nsid.set(
+                        '{%s}val' % NS['w'],
+                        "{0:0{1}X}".format(random.randint(0, 0xffffffff), 8))
 
                 self._insert_abstract_num(anum_element)
             else:


### PR DESCRIPTION
We had some documents where the nsid for some elements was not set. According
to the docs this is valid.