### PR TITLE
Add missing tests for section break fixture files.

### DIFF
--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -2,6 +2,12 @@ from utils import ComposedDocument
 from utils import FixtureDocument
 
 
+def test_section_types_are_correct():
+    composed = ComposedDocument(
+        "continous_section_break.docx", "continous_section_break.docx")
+    assert [s.start_type for s in composed.doc.sections] == [2, 0, 0]
+
+
 def test_continuous_continuous_section_break():
     doc = FixtureDocument("continous_section_break.docx")
     composed = ComposedDocument(

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,0 +1,18 @@
+from utils import ComposedDocument
+from utils import FixtureDocument
+
+
+def test_continuous_continuous_section_break():
+    doc = FixtureDocument("continous_section_break.docx")
+    composed = ComposedDocument(
+        "continous_section_break.docx", "continous_section_break.docx")
+
+    assert composed == doc
+
+
+def test_continuous_odd_section_break():
+    doc = FixtureDocument("continous_odd_section_break.docx")
+    composed = ComposedDocument(
+        "continous_section_break.docx", "odd_section_break.docx")
+
+    assert composed == doc


### PR DESCRIPTION
The files have been added to the fixture in https://github.com/4teamwork/docxcompose/pull/18/files, but apparently not the tests 😂.

![giphy 1](https://user-images.githubusercontent.com/736583/47654575-64a0d880-db8b-11e8-8b25-6b95ef8fdf0e.gif)
