### PR TITLE
Don't handle hyperlink references twice.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix updating doc-properties with non-ascii names. [deiferni]
+- Don't handle hyperlink references twice. [deiferni]
 
 
 1.0.0a14 (2018-12-04)

--- a/docxcompose/composer.py
+++ b/docxcompose/composer.py
@@ -75,8 +75,6 @@ class Composer(object):
             self.add_shapes(doc, element)
             self.add_footnotes(doc, element)
             self.remove_header_and_footer_references(doc, element)
-            # self.add_headers(doc, element)
-            # self.add_footers(doc, element)
             index += 1
 
         self.add_styles_from_other_parts(doc)
@@ -495,18 +493,6 @@ class Composer(object):
             paragraph_props[0].append(num_pr)
         self._numbering_restarted.add(style_id)
 
-    def add_headers(self, doc, element):
-        header_refs = xpath(element, './/w:headerReference')
-        if not header_refs:
-            return
-        for ref in header_refs:
-            rid = ref.get('{%s}id' % NS['r'])
-            rel = doc.part.rels[rid]
-            header_part = self.header_part(content=rel.target_part.blob)
-            my_rel = self.doc.part.rels.get_or_add(
-                rel.reltype, header_part)
-            ref.set('{%s}id' % NS['r'], my_rel.rId)
-
     def header_part(self, content=None):
         """The header part of the document."""
         header_rels = [
@@ -524,18 +510,6 @@ class Composer(object):
             partname, content_type, content, self.doc.part.package)
         self.doc.part.relate_to(header_part, RT.HEADER)
         return header_part
-
-    def add_footers(self, doc, element):
-        footer_refs = xpath(element, './/w:footerReference')
-        if not footer_refs:
-            return
-        for ref in footer_refs:
-            rid = ref.get('{%s}id' % NS['r'])
-            rel = doc.part.rels[rid]
-            footer_part = self.footer_part(content=rel.target_part.blob)
-            my_rel = self.doc.part.rels.get_or_add(
-                rel.reltype, footer_part)
-            ref.set('{%s}id' % NS['r'], my_rel.rId)
 
     def footer_part(self, content=None):
         """The footer part of the document."""

--- a/docxcompose/composer.py
+++ b/docxcompose/composer.py
@@ -77,7 +77,6 @@ class Composer(object):
             self.remove_header_and_footer_references(doc, element)
             # self.add_headers(doc, element)
             # self.add_footers(doc, element)
-            self.add_hyperlinks(doc.part, self.doc.part, element)
             index += 1
 
         self.add_styles_from_other_parts(doc)
@@ -495,19 +494,6 @@ class Composer(object):
                 '<w:ilvl w:val="0"/><w:numId w:val="%s"/></w:numPr>' % next_num_id)
             paragraph_props[0].append(num_pr)
         self._numbering_restarted.add(style_id)
-
-    def add_hyperlinks(self, src_part, dst_part, element):
-        """Add hyperlinks from src_part referenced in element to dst_part."""
-        hyperlink_refs = xpath(element, './/w:hyperlink')
-        for hyperlink_ref in hyperlink_refs:
-            rid = hyperlink_ref.get('{%s}id' % NS['r'])
-            if rid is None:
-                continue
-            rel = src_part.rels[rid]
-            if rel.is_external:
-                new_rid = dst_part.rels.get_or_add_ext_rel(
-                    rel.reltype, rel.target_ref)
-                hyperlink_ref.set('{%s}id' % NS['r'], new_rid)
 
     def add_headers(self, doc, element):
         header_refs = xpath(element, './/w:headerReference')


### PR DESCRIPTION
The hyperlinks are already found by `add_referenced_parts` as they have a `r:id`, see
https://github.com/4teamwork/docxcompose/blob/147ea5019ade4421f322938c31221c983e903c60/docxcompose/composer.py#L97-L105
and the added by `add_relationship` in https://github.com/4teamwork/docxcompose/blob/147ea5019ade4421f322938c31221c983e903c60/docxcompose/composer.py#L107-L114 
as only hyperlinks that are external have an rid according to http://officeopenxml.com/WPhyperlink.php.

The specific `add_hyperlink` method is no longer necessary and everything it does should already be be handled by aforementioned methods.https://github.com/4teamwork/docxcompose/blob/147ea5019ade4421f322938c31221c983e903c60/docxcompose/composer.py#L499-L510

Also perform some cleanup and remove dead/commented-out code.