### PR TITLE
Fix an issue with utf-8 binary_type docproperties.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an issue with non-ascii binary_type docproperties. [deiferni]
 
 
 1.1.0 (2020-04-07)

--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -10,7 +10,7 @@ from docx.oxml.coreprops import CT_CoreProperties
 from docxcompose.utils import NS
 from docxcompose.utils import xpath
 from lxml.etree import QName
-from six import string_types
+from six import binary_type
 from six import text_type
 import pkg_resources
 import re
@@ -40,7 +40,11 @@ def value2vt(value):
     elif isinstance(value, datetime):
         el = parse_xml(CUSTOM_PROPERTY_TYPES['datetime'])
         el.text = value.strftime('%Y-%m-%dT%H:%M:%SZ')
-    elif isinstance(value, string_types):
+    elif isinstance(value, text_type):
+        el = parse_xml(CUSTOM_PROPERTY_TYPES['text'])
+        el.text = value
+    elif isinstance(value, binary_type):
+        value = value.decode('utf-8')
         el = parse_xml(CUSTOM_PROPERTY_TYPES['text'])
         el.text = value
     else:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -716,6 +716,14 @@ def test_add_doc_properties():
     assert props.get('My Date Property') == datetime(2019, 10, 23, 15, 44, 50)
 
 
+def test_add_utf8_property():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    props.add('My Text Property', u'f\xfc\xfc'.encode('utf-8'))
+    assert props.get('My Text Property') == u'f\xfc\xfc'
+
+
 def test_set_doc_properties():
     document = Document(docx_path('docproperties.docx'))
     props = CustomProperties(document)


### PR DESCRIPTION
We allow any string_types docproperties, this is equal to basestring on python2 and can include `str` and `unicode`. We don't handle the case when they are encoded in utf-8 though. This lead to an error when attempting to set doc-properties that are encoded as utf-8.

I would propose to add separate conditionals for binary and text type, assuming utf-8 when we receive a binary value and attempting to decode from utf-8.

This will also still work with ascii docproperties.

Another strategy could be to just allow `text_type` and push conversion to clients. That would be backwards incompatible for python2 though.

Origin: https://4teamwork.atlassian.net/browse/GEVER-279