### PR TITLE
Add method to nullify docproperty.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add method to nullify a docproperty. [deiferni]
 
 
 1.1.2 (2020-06-11)

--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -69,6 +69,11 @@ def vt2value(element):
         return element.text
 
 
+def is_text_property(property):
+    tag = QName(property).localname
+    return tag in ['bstr', 'lpstr', 'lpwstr']
+
+
 class CustomProperties(object):
     """Custom doc properties stored in ``/docProps/custom.xml``.
        Allows updating of doc properties in a document.
@@ -145,6 +150,23 @@ class CustomProperties(object):
             pid += 1
 
         self._update_part()
+
+    def nullify(self, key):
+        """Delete key for non text-properties, set key to empty string for
+        text.
+        """
+
+        props = xpath(
+            self._element,
+            u'.//cp:property[@name="{}"]'.format(key))
+
+        if not props:
+            raise KeyError(key)
+
+        if is_text_property(props[0][0]):
+            self[key] = ''
+        else:
+            del self[key]
 
     def __contains__(self, item):
         props = xpath(

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -754,6 +754,23 @@ def test_delete_doc_properties():
     assert xpath(props._element, u'.//cp:property/@pid') == ['2', '3', '4']
 
 
+def test_nullify_doc_properties():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    props.nullify('Text Property')
+    props.nullify('Number Property')
+    props.nullify('Boolean Property')
+    props.nullify('Date Property')
+    props.nullify('Float Property')
+
+    assert props['Text Property'] == ''
+    assert 'Number Property' not in props
+    assert 'Boolean Property' not in props
+    assert 'Date Property' not in props
+    assert 'Float Property' not in props
+
+
 def test_set_doc_property_on_document_without_properties_creates_new_part():
     document = Document(docx_path('master.docx'))
     props = CustomProperties(document)


### PR DESCRIPTION
This mostly deletes the property but sets it to empty string for text properties. This allows clients to set docproperties to empty string instead deleting it of when this is supported by the doc-property type.

This improves usability in certain cases where there are a lot of text-properties which can be `None` depending on user-input. Word displays an error-message when doc-properties are refreshed but the doc-property does no longer exist:

![Screenshot 2020-07-09 at 11 31 52](https://user-images.githubusercontent.com/736583/87023303-d2fac280-c1d7-11ea-8bc6-3ddc5cffcd48.png)

Nullifying instead of removing the doc-property allows the client library to side-step the error-message in certain cases.

https://4teamwork.atlassian.net/browse/GEVER-638