### PR TITLE
Support updating complex properties with no value.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support updating complex properties with no existing value. [deiferni]
 
 
 1.2.0 (2020-07-13)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -506,10 +506,7 @@ class TestUpdateAllDocproperties(object):
         for i, paragraph in enumerate(document.paragraphs):
             assert u'Bar' == paragraph.text, 'docprop {} was not updated'.format(i+1)
 
-    def test_docproperty_without_separate_does_not_get_updated(self):
-        """It would probably be better to add the value to such a field
-        during update, but that seems out of scope for now.
-        """
+    def test_docproperty_without_separate_does_get_updated(self):
         document = Document(docx_path('complex_field_without_separate.docx'))
         custom_properties = CustomProperties(document)
         properties = custom_properties.find_docprops_in_document()
@@ -544,7 +541,7 @@ class TestUpdateAllDocproperties(object):
         custom_properties.update_all()
 
         # Field with missing separate was not updated
-        assert u'Sachbearbeiter: ' == paragraphs[0].text
+        assert u'Sachbearbeiter: Test User' == paragraphs[0].text
         # Next field was updated correctly
         assert u'Dossier Titel:  Some Title' == paragraphs[1].text
 


### PR DESCRIPTION
Currently such properties were skipped purposefully. This would lead to previously existing empty docproperties not being updated correctly after they have received their initial value.

With this PR we insert the missing runs for such initial updates. We use an existing run as template to make sure that potential formatting information is preserved. The choice of using the first run is somewhat arbitrary though.

There was already a test and a test-document which documented the existing behavior. I have amended the test so that we now can see that the property is updated correctly.

Jira: https://4teamwork.atlassian.net/browse/CA-1082