### PR TITLE
Make Doc Properties case-insensitive

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make Doc Properties case-insensitive. [buchi]
 
 
 1.3.1 (2021-01-13)

--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -10,6 +10,7 @@ from docx.oxml.coreprops import CT_CoreProperties
 from docxcompose.utils import NS
 from docxcompose.utils import word_to_python_date_format
 from docxcompose.utils import xpath
+from lxml.etree import FunctionNamespace
 from lxml.etree import QName
 from six import binary_type
 from six import text_type
@@ -75,6 +76,16 @@ def is_text_property(property):
     return tag in ['bstr', 'lpstr', 'lpwstr']
 
 
+ns = FunctionNamespace(None)
+
+
+# lxml doesn't support XPath 2.0 functions
+# Thus we implement lower-case() as an extension function
+@ns('lower-case')
+def lower_case(context, a):
+    return [el.lower() for el in a]
+
+
 class CustomProperties(object):
     """Custom doc properties stored in ``/docProps/custom.xml``.
        Allows updating of doc properties in a document.
@@ -112,7 +123,7 @@ class CustomProperties(object):
         """Get the value of a property."""
         props = xpath(
             self._element,
-            u'.//cp:property[@name="{}"]'.format(key))
+            u'.//cp:property[lower-case(@name)="{}"]'.format(key.lower()))
 
         if not props:
             raise KeyError(key)
@@ -123,7 +134,7 @@ class CustomProperties(object):
         """Set the value of a property."""
         props = xpath(
             self._element,
-            u'.//cp:property[@name="{}"]'.format(key))
+            u'.//cp:property[lower-case(@name)="{}"]'.format(key.lower()))
         if not props:
             self.add(key, value)
             return
@@ -138,7 +149,7 @@ class CustomProperties(object):
         """Delete a property."""
         props = xpath(
             self._element,
-            u'.//cp:property[@name="{}"]'.format(key))
+            u'.//cp:property[lower-case(@name)="{}"]'.format(key.lower()))
 
         if not props:
             raise KeyError(key)
@@ -159,7 +170,7 @@ class CustomProperties(object):
 
         props = xpath(
             self._element,
-            u'.//cp:property[@name="{}"]'.format(key))
+            u'.//cp:property[lower-case(@name)="{}"]'.format(key.lower()))
 
         if not props:
             raise KeyError(key)
@@ -172,7 +183,7 @@ class CustomProperties(object):
     def __contains__(self, item):
         props = xpath(
             self._element,
-            u'.//cp:property[@name="{}"]'.format(item))
+            u'.//cp:property[lower-case(@name)="{}"]'.format(item.lower()))
         if props:
             return True
         else:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -749,6 +749,14 @@ def test_get_doc_properties():
     assert props.get('Date Property') == datetime(2019, 6, 11, 10, 0)
 
 
+def test_get_doc_property_is_case_insensitive():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    assert props['text property'] == 'Foo Bar'
+    assert props.get('text property') == 'Foo Bar'
+
+
 def test_add_doc_properties():
     document = Document(docx_path('docproperties.docx'))
     props = CustomProperties(document)
@@ -791,6 +799,14 @@ def test_set_doc_properties():
     assert props['Date Property'] == datetime(2019, 10, 20, 12, 0)
 
 
+def test_set_doc_property_is_case_insensitive():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    props['text property'] = 'baz'
+    assert props['Text Property'] == 'baz'
+
+
 def test_delete_doc_properties():
     document = Document(docx_path('docproperties.docx'))
     props = CustomProperties(document)
@@ -802,6 +818,22 @@ def test_delete_doc_properties():
     assert 'Number Property' not in props
 
     assert xpath(props._element, u'.//cp:property/@pid') == ['2', '3', '4']
+
+
+def test_delete_doc_property_is_case_insensitive():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    del props['text property']
+
+    assert 'Text Property' not in props
+
+
+def test_contains_is_case_insensitive():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    assert 'text property' in props
 
 
 def test_nullify_doc_properties():
@@ -819,6 +851,14 @@ def test_nullify_doc_properties():
     assert 'Boolean Property' not in props
     assert 'Date Property' not in props
     assert 'Float Property' not in props
+
+
+def test_nullify_doc_property_is_case_insensitive():
+    document = Document(docx_path('docproperties.docx'))
+    props = CustomProperties(document)
+
+    props.nullify('text property')
+    assert props['Text Property'] == ''
 
 
 def test_set_doc_property_on_document_without_properties_creates_new_part():


### PR DESCRIPTION
Avoids adding Doc Properties with names that differ only in casing, which results in broken documents.

JIRA: https://4teamwork.atlassian.net/browse/CA-2142