### PR TITLE
vt2value(): Convert empty <vt:lpwstr/> nodes to empty string instead of None

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- vt2value(): Convert empty <vt:lpwstr/> nodes to empty string instead of None. [lgraf]
 
 
 1.3.5 (2022-07-08)

--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -67,6 +67,8 @@ def vt2value(element):
         return float(element.text)
     elif tag == 'filetime':
         return CT_CoreProperties._parse_W3CDTF_to_datetime(element.text)
+    elif tag == 'lpwstr':
+        return element.text if element.text else u''
     else:
         return element.text
 


### PR DESCRIPTION
This fixes an asymmetry in how values get converted from Python data types to XML VTs, and vice versa. While empty Python strings are turned into empty `<vt:lpwstr/>` nodes, the same was not true the other way round: When reading docproperties from a document, an empty `<vt:lpwstr/>` node was turned into Python `None`.

This asymmetry caused a bug when updating cached docproperty values: In cases where a docproperty's value in the document's `docProps/custom.xml` was empty, it was parsed to Python `None` and therefore the update of the cached value was skipped in `update_all().

That lead to placeholder values in the document never getting replaced with empty string for those doc properties, because in `update_all()` properties with a value of None simply [get skipped](https://github.com/4teamwork/docxcompose/blob/master/docxcompose/properties.py#L296-L298), and their cached value not updated (which is otherwise correct, because `None` is not a valid value for a doc property - it should always have a value, even if it's the empty string). 

For [CA-4795](https://4teamwork.atlassian.net/browse/CA-4795)