### PR TITLE
Respect document language when updating date fields.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Respect document language when updating datefields. [njohner]
 
 
 1.3.6 (2022-10-05)

--- a/docxcompose/utils.py
+++ b/docxcompose/utils.py
@@ -34,25 +34,11 @@ def xpath(element, xpath_str):
 # https://support.microsoft.com/en-us/office/format-field-results-baa61f5a-5636-4f11-ab4f-6c36ae43508c?ui=en-US&rs=en-US&ad=US#ID0EAABAAA=Date-Time_format_switch_(\@)
 date_format_map = (
     ('Y', 'y'),  # Upper or lower case Y are equivalent
-    ('yyyy', '%Y'),
-    ('yy', '%y'),
-    ('MMMM', '%B'),
-    ('MMM', '%b'),
-    ('MM', '%m'),
-    ('M', '%-%m'),  # We use '%-%m' instead of '%-m' to facilitate negative lookbehind
-    ('d', 'D'),  # Upper or lower case D are equivalent
-    ('DDDD', '%A'),
-    ('DDD', '%a'),
-    ('DD', '%d'),
-    ('D', '%-d'),
-    ('H', 'h'),  # Upper or lower case H are equivalent
-    ('hh', '%H'),
-    ('h', '%-H'),
-    ('(?<!%)mm', '%M'),
-    ('(?<!%)m', '%-M'),
-    ('%-%m', '%-m'),  # Now that we've done the negative lookbehind we can set month format correctly
-    ('ss', '%S'),
-    ('s', '%-S'),
+    ('D', 'd'),
+    ('dddd', 'EEEE'),
+    ('ddd', 'E'),
+    ('am/pm', 'AM/PM'),  # Upper or lower case are equivalent
+    ('AM/PM', 'a')
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'python-docx >= 0.8.8',
         'setuptools',
         'six',
+        'babel',
     ],
     extras_require={
         'test': tests_require,
@@ -44,6 +45,6 @@ setup(
     entry_points={
         'console_scripts': [
             'docxcompose = docxcompose.command:main'
-      ]
-  },
+        ]
+    },
 )

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+from babel.dates import format_datetime
 from datetime import datetime
 from docxcompose.properties import FieldBase
 from docxcompose.utils import word_to_python_date_format
@@ -39,34 +40,34 @@ class TestFieldNameParsing(object):
 class TestFieldDateFormatParsing(object):
 
     def test_can_parse_quoted_date_format(self):
-        node = ' DOCPROPERTY "Propertyname" \\@ "dd-yy-mm" \\* MERGEFORMAT '
+        node = ' DOCPROPERTY "Propertyname" \\@ "ddd-yy-MM" \\* MERGEFORMAT '
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d-%y-%M"
+        assert FieldForTesting(node).date_format == "E-yy-MM"
 
     def test_can_parse_quoted_date_format_with_spaces(self):
-        node = ' DOCPROPERTY "Propertyname" \\@ "dd yy mm" \\* MERGEFORMAT '
+        node = ' DOCPROPERTY "Propertyname" \\@ "ddd yy MM" \\* MERGEFORMAT '
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d %y %M"
+        assert FieldForTesting(node).date_format == "E yy MM"
 
     def test_can_parse_quoted_date_format_with_extra_spaces(self):
-        node = ' DOCPROPERTY "Propertyname"   \\@ "dd yy mm"   \\* MERGEFORMAT'
+        node = ' DOCPROPERTY "Propertyname"   \\@ "ddd yy MM"   \\* MERGEFORMAT'
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d %y %M"
+        assert FieldForTesting(node).date_format == "E yy MM"
 
     def test_can_parse_unquoted_date_format(self):
-        node = ' DOCPROPERTY "Propertyname" \\@ dd-yy-mm \\* MERGEFORMAT '
+        node = ' DOCPROPERTY "Propertyname" \\@ DDD-yy-MM \\* MERGEFORMAT '
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d-%y-%M"
+        assert FieldForTesting(node).date_format == "E-yy-MM"
 
     def test_can_parse_unquoted_date_format_with_spaces(self):
-        node = ' DOCPROPERTY "Propertyname" \\@ dd yy mm \\* MERGEFORMAT '
+        node = ' DOCPROPERTY "Propertyname" \\@ dddd yy MMMM \\* MERGEFORMAT '
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d %y %M"
+        assert FieldForTesting(node).date_format == "EEEE yy MMMM"
 
     def test_can_parse_unquoted_date_format_with_extra_spaces(self):
-        node = ' DOCPROPERTY "Propertyname"   \\@ dd yy mm   \\* MERGEFORMAT'
+        node = ' DOCPROPERTY "Propertyname"   \\@ dd yy MM   \\* MERGEFORMAT'
         assert FieldForTesting(node).name == "Propertyname"
-        assert FieldForTesting(node).date_format == "%d %y %M"
+        assert FieldForTesting(node).date_format == "dd yy MM"
 
 
 class TestFieldDateFormatMapping(object):
@@ -74,47 +75,47 @@ class TestFieldDateFormatMapping(object):
     def test_correctly_maps_simple_date(self):
         date = datetime(2020, 11, 19)
 
-        assert word_to_python_date_format('yy/MM/dd') == '%y/%m/%d'
-        assert word_to_python_date_format('YY/MM/DD') == '%y/%m/%d'
-        assert date.strftime(
-            word_to_python_date_format('yy/MM/dd')) == '20/11/19'
+        assert word_to_python_date_format('yy/MM/dd') == 'yy/MM/dd'
+        assert word_to_python_date_format('YY/MM/DD') == 'yy/MM/dd'
+        assert format_datetime(
+            date, word_to_python_date_format('yy/MM/dd')) == '20/11/19'
 
-        assert word_to_python_date_format('yyyy/MM/dd') == '%Y/%m/%d'
-        assert word_to_python_date_format('YYYY/MM/DD') == '%Y/%m/%d'
-        assert date.strftime(
-            word_to_python_date_format('YYYY/MM/DD')) == '2020/11/19'
+        assert word_to_python_date_format('yyyy/MM/dd') == 'yyyy/MM/dd'
+        assert word_to_python_date_format('YYYY/MM/DD') == 'yyyy/MM/dd'
+        assert format_datetime(
+            date, word_to_python_date_format('YYYY/MM/DD')) == '2020/11/19'
 
     def test_correctly_maps_date_padding(self):
         date = datetime(2001, 2, 4)
 
-        assert word_to_python_date_format('yy/MM/dd') == '%y/%m/%d'
-        assert date.strftime(
-            word_to_python_date_format('yy/MM/dd')) == '01/02/04'
+        assert word_to_python_date_format('yy/MM/dd') == 'yy/MM/dd'
+        assert format_datetime(
+            date, word_to_python_date_format('yy/MM/dd')) == '01/02/04'
 
-        assert word_to_python_date_format('yy/M/d') == '%y/%-m/%-d'
-        assert date.strftime(
-            word_to_python_date_format('yy/M/d')) == '01/2/4'
+        assert word_to_python_date_format('yy/M/d') == 'yy/M/d'
+        assert format_datetime(
+            date, word_to_python_date_format('yy/M/d')) == '01/2/4'
 
     def test_correctly_maps_date_with_weekday_and_month_name(self):
         date = datetime(2020, 11, 19, 23, 59, 43)
 
-        assert word_to_python_date_format('ddd dd MMM yyyy') == '%a %d %b %Y'
-        assert date.strftime(
-            word_to_python_date_format('ddd dd MMM yyyy')) == 'Thu 19 Nov 2020'
+        assert word_to_python_date_format('ddd dd MMM yyyy') == 'E dd MMM yyyy'
+        assert format_datetime(date, word_to_python_date_format(
+            'ddd dd MMM yyyy')) == 'Thu 19 Nov 2020'
 
-        assert word_to_python_date_format('dddd dd MMMM yyyy') == '%A %d %B %Y'
-        assert date.strftime(word_to_python_date_format(
+        assert word_to_python_date_format('dddd dd MMMM yyyy') == 'EEEE dd MMMM yyyy'
+        assert format_datetime(date, word_to_python_date_format(
             'dddd dd MMMM yyyy')) == 'Thursday 19 November 2020'
 
     def test_correctly_maps_date_with_time(self):
         date = datetime(2020, 11, 19, 1, 9, 8)
 
         assert word_to_python_date_format(
-            'ddd DD MMM YYYY HH:mm:ss') == '%a %d %b %Y %H:%M:%S'
-        assert date.strftime(word_to_python_date_format(
+            'ddd DD MMM YYYY HH:mm:ss') == 'E dd MMM yyyy HH:mm:ss'
+        assert format_datetime(date, word_to_python_date_format(
             'ddd DD MMM YYYY HH:mm:ss')) == 'Thu 19 Nov 2020 01:09:08'
 
         assert word_to_python_date_format(
-            'ddd DD MMM YYYY H:m:s') == '%a %d %b %Y %-H:%-M:%-S'
-        assert date.strftime(word_to_python_date_format(
+            'ddd DD MMM YYYY H:m:s') == 'E dd MMM yyyy H:m:s'
+        assert format_datetime(date, word_to_python_date_format(
             'ddd DD MMM YYYY H:m:s')) == 'Thu 19 Nov 2020 1:9:8'


### PR DESCRIPTION
Dates can be language dependent as format can be set to display month and day names. As we were using `strftime` to cast the python datetime to a string when updating date fields, their value would always get updated in the locale of the python interpreter, i.e. usually english. 
We now try to respect the language set in the document to correctly update the date fields. As determining the correct language to use for a given field would be difficult, so instead we simply use the first language tag found in the document or in the styles as language for the whole document.

For https://4teamwork.atlassian.net/browse/CA-4912