### PR TITLE
Replace pkg_resources with importlib_resources

### DIFF
--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -11,11 +11,11 @@ from docx.oxml.coreprops import CT_CoreProperties
 from docxcompose.utils import NS
 from docxcompose.utils import word_to_python_date_format
 from docxcompose.utils import xpath
+from importlib import resources
 from lxml.etree import FunctionNamespace
 from lxml.etree import QName
 from six import binary_type
 from six import text_type
-import pkg_resources
 import re
 
 
@@ -108,8 +108,11 @@ class CustomProperties(object):
             self._element = parse_xml(part.blob)
 
     def _part_template(self):
-        return pkg_resources.resource_string(
-            'docxcompose', 'templates/custom.xml')
+        return (
+            resources.files('docxcompose')
+            .joinpath('templates/custom.xml')
+            .read_bytes()
+        )
 
     def _update_part(self):
         if self.part is None:

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,9 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
+        'importlib-resources >= 1.3;python_version<"3.9"',
         'lxml',
         'python-docx >= 0.8.8',
-        'setuptools',
         'six',
         'babel',
     ],


### PR DESCRIPTION
Fixes #90

See https://setuptools.pypa.io/en/latest/pkg_resources.html#basic-resource-access
See https://docs.python.org/3/library/importlib.resources.html#importlib.resources.read_binary
See https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#platform-specific-dependencies