### PR TITLE
updated imports for python-docx library changes.

### DIFF
--- a/docxcompose/composer.py
+++ b/docxcompose/composer.py
@@ -5,7 +5,7 @@ from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.oxml import serialize_part_xml
 from docx.opc.packuri import PackURI
 from docx.opc.part import Part
-from docx.oxml import parse_xml
+from docx.oxml.parser import parse_xml
 from docx.oxml.section import CT_SectPr
 from docx.parts.numbering import NumberingPart
 from docxcompose.image import ImageWrapper

--- a/docxcompose/properties.py
+++ b/docxcompose/properties.py
@@ -6,7 +6,7 @@ from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docx.opc.oxml import serialize_part_xml
 from docx.opc.packuri import PackURI
 from docx.opc.part import Part
-from docx.oxml import parse_xml
+from docx.oxml.parser import parse_xml
 from docx.oxml.coreprops import CT_CoreProperties
 from docxcompose.utils import NS
 from docxcompose.utils import word_to_python_date_format

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from docx import Document
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
-from docx.oxml import parse_xml
+from docx.oxml.parser import parse_xml
 from docxcompose.properties import ComplexField
 from docxcompose.properties import CUSTOM_PROPERTY_TYPES
 from docxcompose.properties import CustomProperties


### PR DESCRIPTION
There was a release for python-docx library which broke the imports of parse_xml function.

This pull request consists of updated imports to support the new import syntax.