### PR TITLE
python-docx NumberingPart.new() NotImplementedError

### DIFF
--- a/docxcompose/composer.py
+++ b/docxcompose/composer.py
@@ -353,8 +353,10 @@ class Composer(object):
             return
 
         next_num_id, next_anum_id = self._next_numbering_ids()
-
-        src_numbering_part = doc.part.numbering_part
+        try:
+            src_numbering_part = doc.part.numbering_part
+        except NotImplementedError:  # python-docx NumberingPart.new() NotImplementedError
+            src_numbering_part = self.numbering_part()
 
         for num_id in num_ids:
             if num_id in self.num_id_mapping:


### PR DESCRIPTION
Because the 'NumberingPart.new' in the 'part.numbering_part' of the 'python-docx' used is not implemented, it will result in a NotImplementedError.
This is an error in the docx library. I have already submitted the issues. 
Using the `numbering_part` from your 'composer' will fix this issue.
#68 